### PR TITLE
Fix typographical error(s)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -430,7 +430,7 @@ Exposed api:
 
 ### keybindings
 
-This is a module that handles key bindings. By default it can show and hide other modules and show the control window, as explained in the [Using key bindings](#using-key-bindings) section above. However, this module is completely user configureable.
+This is a module that handles key bindings. By default it can show and hide other modules and show the control window, as explained in the [Using key bindings](#using-key-bindings) section above. However, this module is completely user configurable.
 
 The module uses [David Flanagan's keymap.js](https://github.com/luics/Luy.Web/blob/master/!reading-note/!javascript-the-definitive-guide/17/Keymap.js), which is kept in a repository by [鬼道 (luics)](https://github.com/luics)
 


### PR DESCRIPTION
@FirstLegoLeague, I've corrected a typographical error in the documentation of the [displaySystem](https://github.com/FirstLegoLeague/displaySystem) project. Specifically, I've changed configureable to configurable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
