### PR TITLE
do not rerender control window when controls are already there.

### DIFF
--- a/modules/controls.js
+++ b/modules/controls.js
@@ -86,10 +86,14 @@ displaySystem.registerModule({
 
         function open() {
             if (config.url) {
+                //we have a completely custom control window supplied by the user, do not bother rendering
                 var win = window.open(config.url,'fllDisplayControlWindow','resize=yes,width=800,height=550');
             } else {
                 var win = window.open('','fllDisplayControlWindow','resize=yes,width=800,height=550');
                 if (win.document.body.innerHTML) {
+                    // do not render, as the window has already been filled with html.
+                    // Just rendering would add more html to the existing screen
+                    // Rerendering would lose page state
                     return;
                 }
                 win.document.write(html);

--- a/modules/controls.js
+++ b/modules/controls.js
@@ -89,6 +89,9 @@ displaySystem.registerModule({
                 var win = window.open(config.url,'fllDisplayControlWindow','resize=yes,width=800,height=550');
             } else {
                 var win = window.open('','fllDisplayControlWindow','resize=yes,width=800,height=550');
+                if (win.document.body.innerHTML) {
+                    return;
+                }
                 win.document.write(html);
                 init(win.document);
             }


### PR DESCRIPTION
When pressing "C" a second time, the control window rendered a second set of controls. This has been fixed in this pr

closes #40 

